### PR TITLE
Add apple silicon support

### DIFF
--- a/DuckDB.NET/Bindings.csproj
+++ b/DuckDB.NET/Bindings.csproj
@@ -4,7 +4,7 @@
     <Description>DuckDB Bindings for C#.</Description>
     <PackageReleaseNotes>Fix bug when inserting unicode test through appender.</PackageReleaseNotes>
     <RootNamespace>DuckDB.NET</RootNamespace>
-    <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x86;win-x64;linux-x64;linux-arm64;osx-x64,osx-arm64</RuntimeIdentifiers>
     <DuckDbArtifactRoot>https://github.com/duckdb/duckdb/releases/download/v0.7.1</DuckDbArtifactRoot>
   </PropertyGroup>
 
@@ -19,6 +19,7 @@
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-amd64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=linux-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-linux-aarch64.zip" />
     <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-x64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
+    <MSBuild Projects="DownloadNativeLibs.targets" Properties="Rid=osx-arm64;LibUrl=$(DuckDbArtifactRoot)/libduckdb-osx-universal.zip" />
   </Target>
   <Target Name="CleanNativeLibs" BeforeTargets="Clean" Condition="'$(BuildType)' == 'Full' ">
     <RemoveDir Directories="obj\runtimes" />


### PR DESCRIPTION
I'am trying to use the awesome library on my M1 Pro Mac with arm64 but i'am getting `System.DllNotFoundException: Unable to load shared library 'duckdb' or one of its dependencies.` errors.

It seems that just the osx-arm64 runtime is missing. 
This is my attempt to fix this problem and i hope the **osx-universal** should also work on arm64.

Please feel free to correct my small attempt :-)